### PR TITLE
Replace sonarqube-api with custom client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Generated
 .venv
+*.pyc
 
 # Misc
 test.sh

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Tmp Composite Action'
-description: 'Testing Github actions'
+name: 'Sonar Results Action'
+description: 'For use with pull request checks'
 
 runs:
   using: "composite"

--- a/lib/sonar_client.py
+++ b/lib/sonar_client.py
@@ -38,4 +38,6 @@ class SonarClient:
 
         # Call api
         response = requests.get(self.sonar_host_url + request_url, headers=headers)
+
+        # TODO: add handler for response code and errors
         return response.json()

--- a/lib/sonar_client.py
+++ b/lib/sonar_client.py
@@ -1,0 +1,41 @@
+"""
+Client for SonarQube Web API
+"""
+
+import requests
+import sys
+
+
+class SonarClient:
+    """
+    SonarClient class
+    """
+
+    def __init__(self, sonar_host_url, sonar_token):
+        self.sonar_host_url = sonar_host_url
+        self.sonar_token = sonar_token
+
+    def get_project_measures(self, sonar_project_key, pull_request_number, measurable_keys):
+        # Create request url
+        request_url = f"api/measures/component?component={sonar_project_key}&pullRequest={pull_request_number}&metricKeys={measurable_keys}"
+
+        # Call api
+        return self.api_call(request_url)
+
+    def get_qualitygate_status(self, sonar_project_key, pull_request_number):
+        # Create request url
+        request_url = f"api/qualitygates/project_status?projectKey={sonar_project_key}&pullRequest={pull_request_number}"
+
+        # Call api
+        return self.api_call(request_url)
+
+    def api_call(self, request_url):
+        # Set headers
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.sonar_token}"
+        }
+
+        # Call api
+        response = requests.get(self.sonar_host_url + request_url, headers=headers)
+        return response.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyGithub==1.56
-python-sonarqube-api==1.3.4
+PyGithub==1.58.2
+python-sonarqube-api==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 PyGithub==1.58.2
-python-sonarqube-api==2.0.2


### PR DESCRIPTION
Hoping to fix this issue by updating to the latest version of the sonar api package: https://github.com/mx51/msp-dispute-service/actions/runs/5107265135/jobs/9180079068?pr=270

**UPDATE**

Turns out the maintainer for the python-sonarqube-api stuck his project behind a paywall. I added my own client instead, which works for now.